### PR TITLE
remove precompile from internalized toml

### DIFF
--- a/ext/TOML/src/TOML.jl
+++ b/ext/TOML/src/TOML.jl
@@ -1,5 +1,3 @@
-__precompile__(true)
-
 module TOML
 
     if VERSION < v"0.6-"


### PR DESCRIPTION
This causes Pkg3 to precompile. If we want that, it should probably be in the Pkg3.jl file.