### PR TITLE
 query for install if package exists in registry but not found locally 

### DIFF
--- a/ext/TerminalMenus/README.md
+++ b/ext/TerminalMenus/README.md
@@ -117,6 +117,8 @@ All interface customization is done through the keyword only
  - `checked::String="[X]"|"✓"`: string to use for checked
  - `unchecked::String="[ ]"|"⬚")`: string to use for unchecked
  - `scroll::Symbol=:na`: If `:wrap` then wrap the cursor around top and bottom, if :`nowrap` do not wrap cursor
+ - `supress_output::Bool=false`: For testing. If true, menu will not be printed to console.
+ - `ctrl_c_interrupt::Bool=true`: If `false`, return empty on ^C, if `true` throw InterruptException() on ^C
 
 ## Examples
 

--- a/ext/TerminalMenus/src/AbstractMenu.jl
+++ b/ext/TerminalMenus/src/AbstractMenu.jl
@@ -99,21 +99,23 @@ keypress(m::AbstractMenu, i::UInt32) = false
 Display the menu and enter interactive mode. Returns `m.selected` which
 varies based on menu type.
 """
-function request(m::AbstractMenu)
+request(m::AbstractMenu) = request(terminal, m)
+
+function request(term::Base.Terminals.TTYTerminal, m::AbstractMenu)
     cursor = 1
 
     menu_header = header(m)
-    if menu_header != ""
-        println(header(m))
+    if !CONFIG[:supress_output] && menu_header != ""
+        println(term.out_stream, menu_header)
     end
 
-    printMenu(m, cursor, init=true)
+    printMenu(term.out_stream, m, cursor, init=true)
 
-    enableRawMode()
-    print("\x1b[?25l") # hide the cursor
+    raw_mode_enabled = enableRawMode(term)
+    raw_mode_enabled && print(term.out_stream, "\x1b[?25l") # hide the cursor
     try
         while true
-            c = readKey()
+            c = readKey(term.in_stream)
 
             if c == Int(ARROW_UP)
 
@@ -145,26 +147,57 @@ function request(m::AbstractMenu)
                     m.pageoffset = 0
                 end
 
+            elseif c == Int(PAGE_UP)
+                # If we're at the bottom, move the page 1 less to move the cursor up from
+                # the bottom entry, since we try to avoid putting the cursor at bounds.
+                m.pageoffset -= m.pagesize - (cursor == length(options(m)) ? 1 : 0)
+                m.pageoffset = max(m.pageoffset, 0)
+                cursor -= m.pagesize
+                cursor = max(cursor, 1)
+
+            elseif c == Int(PAGE_DOWN)
+                m.pageoffset += m.pagesize - (cursor == 1 ? 1 : 0)
+                m.pageoffset = min(m.pageoffset, length(options(m)) - m.pagesize)
+                cursor += m.pagesize
+                cursor = min(cursor, length(options(m)))
+
+            elseif c == Int(HOME_KEY)
+                cursor = 1
+                m.pageoffset = 0
+
+            elseif c == Int(END_KEY)
+                cursor = length(options(m))
+                m.pageoffset = length(options(m)) - m.pagesize
+
             elseif c == 13 # <enter>
                 # will break if pick returns true
                 pick(m, cursor) && break
-            elseif c == UInt32('q') || c == 3 # ctrl-c (cancel)
+            elseif c == UInt32('q')
                 cancel(m)
                 break
+            elseif c == 3 # ctrl-c
+                cancel(m)
+                if CONFIG[:ctrl_c_interrupt]
+                    throw(InterruptException())
+                else
+                    break
+                end
             else
                 # will break if keypress returns true
                 keypress(m, c) && break
             end
 
-            printMenu(m, cursor)
+            printMenu(term.out_stream, m, cursor)
         end
     finally
         # always disable raw mode even even if there is an
         #  exception in the above loop
-        print("\x1b[?25h") #unhide cursor
-        disableRawMode()
+        if raw_mode_enabled
+            print(term.out_stream, "\x1b[?25h") # unhide cursor
+            disableRawMode(term)
+        end
     end
-    println()
+    println(term.out_stream)
 
     return m.selected
 end
@@ -172,33 +205,43 @@ end
 
 """
 
-    request(msg::AbstractString, m::AbstractMenu)
+    request([term,] msg::AbstractString, m::AbstractMenu)
 
-Shorthand for  `println(msg); request(m)`.
+Shorthand for `println(msg); request(m)`.
 """
-function request(msg::AbstractString, m::AbstractMenu)
-    println(msg)
-    request(m)
+request(msg::AbstractString, m::AbstractMenu) =
+    request(terminal, msg, m)
+
+function request(term::Base.Terminals.TTYTerminal,
+                 msg::AbstractString, m::AbstractMenu)
+    println(term.out_stream, msg)
+    request(term, m)
 end
 
 
 
 # The generic printMenu function is used for displaying the state of a
 #   menu to the screen. Menus must implement `writeLine` and `options`
-#   and have feilds `pagesize::Int` and `pageoffset::Int` as part of
+#   and have fields `pagesize::Int` and `pageoffset::Int` as part of
 #   their type definition
-function printMenu(m::AbstractMenu, cursor::Int; init::Bool=false)
+function printMenu(out, m::AbstractMenu, cursor::Int; init::Bool=false)
+    CONFIG[:supress_output] && return
+
     buf = IOBuffer()
 
-    # Move the cursor to the begining of where it should print
+    # Move the cursor to the beginning of where it should print
     # Don't do this on the initial print
     lines = m.pagesize-1
-    !init && print(buf, "\x1b[999D\x1b[$(lines)A")
+    if init
+        m.pageoffset = 0
+    else
+        print(buf, "\x1b[999D\x1b[$(lines)A")
+    end
 
     for i in (m.pageoffset+1):(m.pageoffset + m.pagesize)
         print(buf, "\x1b[2K")
 
-        if i ==  m.pageoffset+1 && m.pageoffset > 0
+        if i == m.pageoffset+1 && m.pageoffset > 0
             # first line && scrolled past first entry
             print(buf, CONFIG[:up_arrow])
         elseif i == m.pagesize+m.pageoffset && i != length(options(m))
@@ -215,5 +258,5 @@ function printMenu(m::AbstractMenu, cursor::Int; init::Bool=false)
         i != (m.pagesize+m.pageoffset) && print(buf, "\r\n")
     end
 
-    print(String(take!(buf)))
+    print(out, String(take!(buf)))
 end

--- a/ext/TerminalMenus/src/TerminalMenus.jl
+++ b/ext/TerminalMenus/src/TerminalMenus.jl
@@ -1,5 +1,12 @@
 module TerminalMenus
 
+terminal = nothing  # The user terminal
+
+function __init__()
+    global terminal
+    terminal = Base.Terminals.TTYTerminal(get(ENV, "TERM", is_windows() ? "" : "dumb"), STDIN, STDOUT, STDERR)
+end
+
 include("util.jl")
 include("config.jl")
 

--- a/ext/TerminalMenus/src/config.jl
+++ b/ext/TerminalMenus/src/config.jl
@@ -15,7 +15,9 @@ Keyword-only function to configure global menu parameters
  - `down_arrow::Char='v'|'↓'`: character to use for down arrow
  - `checked::String="[X]"|"✓"`: string to use for checked
  - `unchecked::String="[ ]"|"⬚")`: string to use for unchecked
- - `scroll::Symbol=:na`: If `:wrap` then wrap the cursor around top and bottom, if :`nowrap` do not wrap cursor
+ - `scroll::Symbol=:nowrap`: If `:wrap` then wrap the cursor around top and bottom, if :`nowrap` do not wrap cursor
+ - `supress_output::Bool=false`: For testing. If true, menu will not be printed to console.
+ - `ctrl_c_interrupt::Bool=true`: If `false`, return empty on ^C, if `true` throw InterruptException() on ^C
 """
 function config(;charset::Symbol = :na,
                 scroll::Symbol = :na,
@@ -23,7 +25,9 @@ function config(;charset::Symbol = :na,
                 up_arrow::Char = '\0',
                 down_arrow::Char = '\0',
                 checked::String = "",
-                unchecked::String = "")
+                unchecked::String = "",
+                supress_output::Union{Void, Bool}=nothing,
+                ctrl_c_interrupt::Union{Void, Bool}=nothing)
 
     if !(charset in [:na, :ascii, :unicode])
         error("charset should be :ascii or :unicode, recieved $charset")
@@ -53,6 +57,14 @@ function config(;charset::Symbol = :na,
         unchecked = "⬚"
     end
 
+    if isa(supress_output, Bool)
+        CONFIG[:supress_output] = supress_output
+    end
+
+    if isa(ctrl_c_interrupt, Bool)
+        CONFIG[:ctrl_c_interrupt] = ctrl_c_interrupt
+    end
+
     cursor != '\0'      && (CONFIG[:cursor] = cursor)
     up_arrow != '\0'    && (CONFIG[:up_arrow] = up_arrow)
     down_arrow != '\0'  && (CONFIG[:down_arrow] = down_arrow)
@@ -64,4 +76,4 @@ function config(;charset::Symbol = :na,
 end
 
 # Set up defaults
-config(charset=:ascii, scroll=:nowrap)
+config(charset=:ascii, scroll=:nowrap, supress_output=false, ctrl_c_interrupt=true)

--- a/ext/TerminalMenus/test/multiselect_menu.jl
+++ b/ext/TerminalMenus/test/multiselect_menu.jl
@@ -29,3 +29,7 @@ TerminalMenus.writeLine(buf, multi_menu, 1, true)
 TerminalMenus.config(charset=:unicode)
 TerminalMenus.writeLine(buf, multi_menu, 1, true)
 @test String(take!(buf)) == string(CONFIG[:cursor], " ", CONFIG[:unchecked], " 1")
+
+# Test SDTIN
+multi_menu = MultiSelectMenu(string.(1:10))
+@test simulateInput(Set([1,2]), multi_menu, :enter, :down, :enter, 'd')

--- a/ext/TerminalMenus/test/radio_menu.jl
+++ b/ext/TerminalMenus/test/radio_menu.jl
@@ -32,3 +32,7 @@ TerminalMenus.writeLine(buf, radio_menu, 1, true)
 TerminalMenus.config(charset=:unicode)
 TerminalMenus.writeLine(buf, radio_menu, 1, true)
 @test String(take!(buf)) == string(CONFIG[:cursor], " 1")
+
+# Test using STDIN
+radio_menu = RadioMenu(string.(1:10))
+@test simulateInput(3, radio_menu, :down, :down, :enter)

--- a/ext/TerminalMenus/test/runtests.jl
+++ b/ext/TerminalMenus/test/runtests.jl
@@ -1,6 +1,27 @@
 using TerminalMenus
 using Base.Test
 
+TerminalMenus.config(supress_output=true)
+
+function simulateInput(expectedResult, menu::TerminalMenus.AbstractMenu, keys...)
+    # If we cannot write to the buffer, skip the test
+    !(:buffer in fieldnames(STDIN)) && return true
+
+    keydict =  Dict(:up => "\e[A",
+                    :down => "\e[B",
+                    :enter => "\r")
+
+    for key in keys
+        if isa(key, Symbol)
+            write(STDIN.buffer, keydict[key])
+        else
+            write(STDIN.buffer, "$key")
+        end
+    end
+
+    request(menu) == expectedResult
+end
+
 include("radio_menu.jl")
 include("multiselect_menu.jl")
 

--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module Pkg3
 
 const DEPOTS = [joinpath(homedir(), ".julia")]
@@ -11,6 +12,15 @@ include("Types.jl")
 include("Display.jl")
 include("Operations.jl")
 include("REPLMode.jl")
+
+
+@enum LoadErrorChoice LOAD_ERROR_QUERY LOAD_ERROR_INSTALL LOAD_ERROR_ERROR
+
+Base.@kwdef mutable struct GlobalSettings
+    load_error_choice::LoadErrorChoice = LOAD_ERROR_QUERY # query, install, or error, when not finding package on import
+end
+
+GLOBAL_SETTINGS = GlobalSettings()
 
 function __init__()
     push!(empty!(LOAD_PATH), dirname(dirname(@__DIR__)))
@@ -35,14 +45,44 @@ function _find_in_path(name::String, wd::Union{Void,String})
         path = joinpath(wd, name)
         Base.isfile_casesensitive(path) && return path
     end
+
     info = Pkg3.Operations.package_env_info(base, verb = "use")
-    info == nothing && return nothing
-    haskey(info, "uuid") || return nothing
-    haskey(info, "hash-sha1") || return nothing
+    info == nothing && @goto find_global
+    haskey(info, "uuid") || @goto find_global
+    haskey(info, "hash-sha1") || @goto find_global
     uuid = Base.Random.UUID(info["uuid"])
     hash = Pkg3.Types.SHA1(info["hash-sha1"])
     path = Pkg3.Operations.find_installed(uuid, hash)
-    ispath(path) ? joinpath(path, "src", name) : nothing
+    ispath(path) && return joinpath(path, "src", name)
+
+    # If we still haven't found the file, look if the package exists in the registry
+    # and query the user (if we are interactive) to install it.
+    @label find_global
+    if isinteractive()
+        env = Types.EnvCache()
+        pkgspec = [Types.PackageSpec(base)]
+
+        r = Operations.registry_resolve!(env, pkgspec)
+        Types.has_uuid(r[1]) || return nothing
+
+        GLOBAL_SETTINGS.load_error_choice == LOAD_ERROR_INSTALL && @goto install
+        GLOBAL_SETTINGS.load_error_choice == LOAD_ERROR_ERROR   && return nothing
+
+        choice = TerminalMenus.request("Could not find package \e[1m$(base)\e[22m, do you want to install it?",
+                       TerminalMenus.RadioMenu(["yes", "yes (remember)", "no", "no (remember)"]))
+
+        if choice == 3 || choice == 4
+            choice == 4 && (GLOBAL_SETTINGS.load_error_choice = LOAD_ERROR_ERROR)
+            return nothing
+        end
+
+        choice == 2 && (GLOBAL_SETTINGS.load_error_choice = LOAD_ERROR_INSTALL)
+        @label install
+        Pkg3.Operations.ensure_resolved(env, pkgspec, true)
+        Pkg3.Operations.add(env, pkgspec)
+        return _find_in_path(name, wd)
+    end
+    return nothing
 end
 
 Base.find_in_path(name::String, wd::Void) = _find_in_path(name, wd)


### PR DESCRIPTION
E.g when including a file with:

```jl
import Example
import Crayons
```

gives:

```jl
julia> include("/Users/kristoffer/Documents/mpkg.jl")
Could not find package Example, do you want to install it?
   yes
 > yes (remember)
   no
   no (remember)
INFO: Resolving package versions
INFO: Installing Compat
INFO: Updating "../Project.toml"
 [7876af07] + Example v0.4.1
INFO: Updating "../Manifest.toml"
 [34da2185] ↑ Compat v0.31.0 ⇒ v0.34.0
 [7876af07] + Example v0.4.1
INFO: Resolving package versions
INFO: Installing Crayons
INFO: Updating "../Project.toml"
 [a759f4b9] + TimerOutputs v0.3.0
INFO: Updating "../Manifest.toml"
 [a8cc5b0e] + Crayons v0.4.0
 [a759f4b9] + TimerOutputs v0.3.0
INFO: Recompiling stale cache file /Users/kristoffer/.julia/lib/v0.6/TimerOutputs.ji for module TimerOutputs.
```

Also, update TerminalMenus (without that I got some stream errors).

This adds a `GlobalSetting` type that could potentially later be "mapped" to a file where a user can set default settings.