### PR TITLE
enable precompilation for Pkg3

### DIFF
--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -1,3 +1,4 @@
+__precompile__(true)
 module Pkg3
 
 const DEPOTS = [joinpath(homedir(), ".julia")]


### PR DESCRIPTION
Otherwise loading precompiled packages does not work (funnily enough).